### PR TITLE
Update README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 
 
-# SafeData
+# Querying personal MasterData Information with SafeData
 
 The SafeData app provides an easy to use, configurable middleware to retrieve and save MasterData (V1 & V2) information directly on the front-end (or through another back-end as well).
 


### PR DESCRIPTION
Change the documentation's name to follow the tutorials available on the B2B setup section of Developer Portal.

As the doc will be available on the section STOREFRONT IMPLEMENTATION GUIDES > [B2B Setup](https://developers.vtex.com/vtex-developer-docs/docs/b2b-setup), we should keep the pattern of the articles' titles from this section, which are tutorials for B2B setup (Configuring, Installing, Customizing...).

cc: @ConradoClark 