### PR TITLE
update canCreate logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
+- canCreate for anonymous user of the settings at CL and AD entities
+
+## [1.1.0] - 2022-12-23
+### Fixed
 - prevent anonymous user from altering existing document with a single-valued index.
 
 ## [1.0.1] - 2022-09-15


### PR DESCRIPTION
This PR refers to a reported problem about the settings for creating anonymous documents in the CL and AD entity.

Application settings were being overwritten by constants determined within the App for these entities. Therefore, a logic was built to read the settings correctly, prioritizing this entry and using the application constant as a fallback.

- Previous scenario: It was not possible to prohibit creating documents anonymously in CL and AD entities.

- Current scenario: The flag determined in the safedata settings for the CL and AD entities is respected, allowing the blocking of new documents if the merchant wants to.

**Before the publication of this improvement, it is necessary to do a release note with this update, as it may generate some strange behavior for the stores.**